### PR TITLE
Allow query strings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,10 +67,10 @@ where
 {
     trace!(
         "serve_function:: req.uri() == {}, req.method() == {}",
-        req.uri(),
+        req.uri().path(),
         req.method()
     );
-    if req.uri() != "/metrics" {
+    if req.uri().path() != "/metrics" {
         Ok(Response::builder()
             .status(StatusCode::NOT_FOUND)
             .body(hyper::Body::empty())


### PR DESCRIPTION
Allow URIs to contain query strings, useful for writing probes where prometheus controls targets or options