### PR TITLE
Remove feature annotation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(async_closure)]
 extern crate failure;
 extern crate serde_json;
 use http::StatusCode;


### PR DESCRIPTION
This annotation breaks compilation with a stable rustc 1.39.0 due to the
following error:

```
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> src/lib.rs:1:1
  |
1 | #![feature(async_closure)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error
```

This is a problem when build stuff e.g. for distros where you'd
preferably use rust-stable. Also, the async_closure feature is available
in rust-stable[1].

[1] https://areweasyncyet.rs/