### PR TITLE
Add timestamp option to render_sample

### DIFF
--- a/examples/folder_size.rs
+++ b/examples/folder_size.rs
@@ -77,10 +77,10 @@ async fn main() {
 
             let mut attributes = Vec::new();
             attributes.push(("folder", "/var/log/"));
-            s.push_str(&pc.render_sample(Some(&attributes), total_size_log));
+            s.push_str(&pc.render_sample(Some(&attributes), total_size_log, None));
 
             attributes[0].1 = "/tmp";
-            s.push_str(&pc.render_sample(Some(&attributes), total_size_tmp));
+            s.push_str(&pc.render_sample(Some(&attributes), total_size_tmp, None));
 
             Ok(s)
         }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -21,25 +21,22 @@ async fn main() {
     let addr = ([0, 0, 0, 0], 32221).into();
     println!("starting exporter on {}", addr);
 
-    render_prometheus(addr, MyOptions::default(), |request, options| {
-        async move {
-            println!(
-                "in our render_prometheus(request == {:?}, options == {:?})",
-                request, options
-            );
+    render_prometheus(addr, MyOptions::default(), |request, options| async move {
+        println!(
+            "in our render_prometheus(request == {:?}, options == {:?})",
+            request, options
+        );
 
-            let total_size_log = calculate_file_size("/var/log").unwrap();
+        let total_size_log = calculate_file_size("/var/log").unwrap();
 
-            let pc =
-                PrometheusMetric::new("folder_size", MetricType::Counter, "Size of the folder");
-            let mut s = pc.render_header();
+        let pc = PrometheusMetric::new("folder_size", MetricType::Counter, "Size of the folder");
+        let mut s = pc.render_header();
 
-            let mut attributes = Vec::new();
-            attributes.push(("folder", "/var/log/"));
-            s.push_str(&pc.render_sample(Some(&attributes), total_size_log));
+        let mut attributes = Vec::new();
+        attributes.push(("folder", "/var/log/"));
+        s.push_str(&pc.render_sample(Some(&attributes), total_size_log, None));
 
-            Ok(s)
-        }
+        Ok(s)
     })
     .await;
 }


### PR DESCRIPTION
Fixes #17 
This is a simple implementation where the parameter is `Option<i64>`. This leaves working with dates to the crate's users.
From prometheus' documentation:
> The `timestamp` is an int64 (milliseconds since epoch, i.e. 1970-01-01 00:00:00 UTC, excluding leap seconds).

I think I could use https://docs.rs/chrono/0.4.11/chrono/struct.DateTime.html#method.timestamp_millis instead, so users can pass `chrono`'s `DateTime`. The question is whether this is desirable, taking a hard dependency on `chrono`. Another option would be an `enum` with options of either a `DateTime` or an `i64`. (I will have to implement it for the exporter I'm writing anyway, so the question is just if it should be in this base crate, or not.) Let me know what you think @MindFlavor