### PR TITLE
Bugfix: fixed wrong feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus_exporter_base"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name           = "prometheus_exporter_base"
-version        = "1.2.0"
+version        = "1.3.0"
 authors        = ["Francesco Cogno <francesco.cogno@outlook.com>"]
 edition        = "2018"
 description    = "Prometheus Rust exporters base crate with optional boilerplate"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ render_prometheus(addr, MyOptions::default(), |request, options| {
     async {
     	Ok("it works!".to_owned())
     }
-});
+}).await;
 ```
 
 As you can see, in order to keep things simple, the Hyper server does not enforce anything to the output. It's up to you to return a meaningful string by using the above mentioned structs. 

--- a/examples/folder_size.rs
+++ b/examples/folder_size.rs
@@ -1,7 +1,6 @@
 use clap::{crate_authors, crate_name, crate_version, Arg};
 use log::{info, trace};
 use prometheus_exporter_base::prelude::*;
-use prometheus_exporter_base::render_prometheus;
 use std::env;
 use std::fs::read_dir;
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,4 @@
 use prometheus_exporter_base::prelude::*;
-use prometheus_exporter_base::render_prometheus;
 use std::fs::read_dir;
 
 #[derive(Debug, Clone, Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ where
     Fut: Future<Output = Result<String, Box<dyn Error + Send + Sync>>> + Send + 'static,
     O: std::fmt::Debug + Sync + Send + 'static,
 {
-    info!("Listening on http://{}", addr);
+    info!("Listening on http://{}/metrics", addr);
 
     let f = f.clone();
     let options = options.clone();

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,3 +1,3 @@
-#[cfg(hyper_server)]
+#[cfg(feature = "hyper_server")]
 pub use crate::render_prometheus;
 pub use crate::{MetricType, PrometheusInstance, PrometheusMetric};


### PR DESCRIPTION
There was a typo in the `prelude` file that didn't export the `render_prometheus` function correctly (if the `hyper_server` feature is enabled).

This addresses #22.