### PR TITLE
Add POST support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ where
             .status(StatusCode::NOT_FOUND)
             .body(hyper::Body::empty())
             .unwrap())
-    } else if req.method() != "GET" {
+    } else if req.method() != "GET" && req.method() != "POST" {
         Ok(Response::builder()
             .status(StatusCode::METHOD_NOT_ALLOWED)
             .body(hyper::Body::empty())

--- a/src/prometheus_instance.rs
+++ b/src/prometheus_instance.rs
@@ -1,5 +1,4 @@
 use crate::{RenderToPrometheus, ToAssign, Yes};
-use num::Num;
 use std::convert::Into;
 use std::marker::PhantomData;
 use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
@@ -11,7 +10,7 @@ impl ToAssign for MissingValue {}
 #[derive(Debug, Clone)]
 pub struct PrometheusInstance<'a, N, ValueSet>
 where
-    N: Num + std::fmt::Display + std::fmt::Debug,
+    N: std::fmt::Display + std::fmt::Debug,
 {
     labels: Vec<(&'a str, &'a str)>,
     value: Option<N>,
@@ -21,7 +20,7 @@ where
 
 impl<'a, N> PrometheusInstance<'a, N, MissingValue>
 where
-    N: Num + std::fmt::Display + std::fmt::Debug,
+    N: std::fmt::Display + std::fmt::Debug,
 {
     pub fn new() -> Self {
         Self {
@@ -35,7 +34,7 @@ where
 
 impl<'a, N> Default for PrometheusInstance<'a, N, MissingValue>
 where
-    N: Num + std::fmt::Display + std::fmt::Debug,
+    N: std::fmt::Display + std::fmt::Debug,
 {
     fn default() -> Self {
         Self::new()
@@ -44,7 +43,7 @@ where
 
 impl<'a, N, ValueSet> PrometheusInstance<'a, N, ValueSet>
 where
-    N: Num + std::fmt::Display + std::fmt::Debug,
+    N: std::fmt::Display + std::fmt::Debug,
 {
     pub fn with_label<L, V>(self, l: L, v: V) -> Self
     where
@@ -128,7 +127,7 @@ where
 
 impl<'a, N> RenderToPrometheus for PrometheusInstance<'a, N, Yes>
 where
-    N: Num + std::fmt::Display + std::fmt::Debug,
+    N: std::fmt::Display + std::fmt::Debug,
 {
     fn render(&self) -> String {
         let mut s = String::new();


### PR DESCRIPTION
[`node_exporter`](https://github.com/prometheus/node_exporter) from Prometheus does not enforce `GET` method and supports both `GET` and `POST`.

I  encountered some software that relies on the fact that POST request is allowed to query exporters. I don't see a specific reason to not support both HTTP method.