### PR TITLE
Send WWW-Authenticate header when unauthenticated.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@ where
     if !is_authorized {
         Ok(Response::builder()
             .status(StatusCode::UNAUTHORIZED)
-            .header("WWW-Authenticate", "Basic")
+            .header("WWW-Authenticate", "Basic realm=\"Prometheus exporter\"")
             .body(hyper::Body::empty())
             .unwrap())
     } else if req.uri().path() != "/metrics" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,7 @@ where
     if !is_authorized {
         Ok(Response::builder()
             .status(StatusCode::UNAUTHORIZED)
+            .header("WWW-Authenticate", "Basic")
             .body(hyper::Body::empty())
             .unwrap())
     } else if req.uri().path() != "/metrics" {


### PR DESCRIPTION
Per [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.2) a server MUST send a WWW-Authenticate header with a 401 response.